### PR TITLE
ci: fix deprecations

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -67,10 +67,10 @@ jobs:
         id: coverage
         run: |
           if [ "${{ matrix.config.coverage }}" = "yes" ]; then
-            echo "::set-output name=coverage::pcov"
-            echo '::set-output name=ini::pcov.directory=inc, pcov.exclude="~/(vendor|node_modules)/~"'
+            echo coverage=pcov >> "${GITHUB_OUTPUT}"
+            echo 'ini=pcov.directory=inc, pcov.exclude="~/(vendor|node_modules)/~"' >> "${GITHUB_OUTPUT}"
           else
-            echo "::set-output name=coverage::none"
+            echo coverage=none >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Set up PHP


### PR DESCRIPTION
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/