### PR TITLE
fix: DEP0137: close file handle explicitly

### DIFF
--- a/tests/e2e/specs/setup.ts
+++ b/tests/e2e/specs/setup.ts
@@ -13,6 +13,7 @@ test.describe('Set up', () => {
         try {
             const fd = await open(storagePath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o644);
             await writeFile(fd, '{}');
+            await fd.close();
         } catch {
             // Do nothing, file exists
         }


### PR DESCRIPTION
> (node:10542) Warning: Closing file descriptor 27 on garbage collection
> (Use `node --trace-warnings ...` to show where the warning was created)
> (node:10542) [DEP0137] DeprecationWarning: Closing a FileHandle object on garbage collection is deprecated. Please close FileHandle objects explicitly using FileHandle.prototype.close(). In the future, an error will be thrown if a file descriptor is closed during garbage collection.
