### PR TITLE
fix: install `twentytwentyfive` if no themes available

### DIFF
--- a/.devcontainer/update-content.sh
+++ b/.devcontainer/update-content.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-use-wptl latest
-if [ -d node_modules ]; then
-    npm install
-else
-    npm ci
+if [ "$(wp theme list --format=count)" = "0" ]; then
+    wp theme install --activate twentytwentyfive
 fi


### PR DESCRIPTION
This pull request updates the `.devcontainer/update-content.sh` script to ensure that a WordPress theme is installed and activated if none are present. The previous logic for installing Node.js dependencies has been removed.

Theme installation logic:

* Added a check for the number of installed WordPress themes and automatically installs and activates the `twentytwentyfive` theme if none are present. (`.devcontainer/update-content.sh`)

Removed Node.js dependency installation:

* Removed the logic that installed Node.js dependencies using `npm install` or `npm ci`. (`.devcontainer/update-content.sh`)