### PR TITLE
refactor(e2e): make tests more robust

### DIFF
--- a/tests/e2e/lib/adminpage.ts
+++ b/tests/e2e/lib/adminpage.ts
@@ -83,7 +83,7 @@ export class AdminPage extends BasePage {
     public async logOut(): Promise<BasePage> {
         await this.secondaryMenu.hover();
         await this.adminBarLogOut.click();
-        await this.page.waitForLoadState('load');
+        await this.page.waitForLoadState('domcontentloaded');
 
         return new BasePage(this.page);
     }

--- a/tests/e2e/lib/login.pom.ts
+++ b/tests/e2e/lib/login.pom.ts
@@ -62,9 +62,9 @@ export class LoginPage extends BasePage {
 
     public async lostPassword(): Promise<LostPasswordPage | Page> {
         await this.lostPasswordLink.click();
-        await this.page.waitForLoadState('load');
+        await this.page.waitForURL((url) => url.pathname.endsWith('/wp-login.php'), { waitUntil: 'domcontentloaded' });
         const url = new URL(this.page.url());
-        if (url.pathname.endsWith('/wp-login.php') && url.searchParams.get('action') === 'lostpassword') {
+        if (url.searchParams.get('action') === 'lostpassword') {
             return new LostPasswordPage(this.page);
         }
 

--- a/tests/e2e/lib/lostpassword.pom.ts
+++ b/tests/e2e/lib/lostpassword.pom.ts
@@ -42,7 +42,7 @@ export class LostPasswordPage extends BasePage {
     public async resetPassword(login: string): Promise<LostPasswordPage | ResetPasswordSuccessPage | BasePage> {
         await this.loginField.fill(login);
         await this.getPasswordButton.click();
-        await this.page.waitForLoadState('load');
+        await this.page.waitForURL((url) => url.pathname.endsWith('/wp-login.php'), { waitUntil: 'domcontentloaded' });
 
         const url = new URL(this.lastNavigationRequest?.url() ?? '');
         if (url.pathname.endsWith('/wp-login.php')) {

--- a/tests/e2e/lib/userspage.pom.ts
+++ b/tests/e2e/lib/userspage.pom.ts
@@ -7,6 +7,7 @@ export class UsersPage extends AdminPage {
     public readonly addUserLinkLocator: Locator;
     public readonly searchUsersInputLocator: Locator;
     public readonly searchSubmitButtonLocator: Locator;
+    public readonly noItemsLocator: Locator;
 
     public constructor(page: Page) {
         super(page);
@@ -15,15 +16,16 @@ export class UsersPage extends AdminPage {
         this.addUserLinkLocator = page.locator('a.page-title-action');
         this.searchUsersInputLocator = page.locator('input#user-search-input');
         this.searchSubmitButtonLocator = page.locator('input#search-submit');
+        this.noItemsLocator = page.locator('#the-list > .no-items');
     }
 
     public visit(): Promise<Response> {
-        return this.page.goto('/wp-admin/users.php') as Promise<Response>;
+        return this.page.goto('./wp-admin/users.php') as Promise<Response>;
     }
 
     public async editUserByID(id: number): Promise<BasePage> {
         await this.userRowLocator(id).locator('td.username > strong > a').click();
-        await this.page.waitForLoadState('load');
+        await this.page.waitForLoadState('domcontentloaded');
         return new BasePage(this.page);
     }
 
@@ -31,7 +33,7 @@ export class UsersPage extends AdminPage {
         const rowActionsLocator = this.userRowActionLocator(id)
         await rowActionsLocator.hover();
         await rowActionsLocator.locator(`span.${action} > a`).click();
-        await this.page.waitForLoadState('load');
+        await this.page.waitForLoadState('domcontentloaded');
         return new BasePage(this.page);
     }
 
@@ -50,12 +52,8 @@ export class UsersPage extends AdminPage {
     public async searchForUsers(search: string): Promise<this> {
         await this.searchUsersInputLocator.fill(search);
         await this.searchSubmitButtonLocator.click();
-        await this.page.waitForLoadState('load');
+        await this.page.waitForURL((url) => url.pathname.endsWith('/users.php'), { waitUntil: 'domcontentloaded' });
         return this;
-    }
-
-    public async usersFound(): Promise<boolean> {
-        return await this.page.locator('#the-list > .no-items').count() === 0;
     }
 
     private userRowLocator(id: number): Locator {

--- a/tests/e2e/specs/users.spec.ts
+++ b/tests/e2e/specs/users.spec.ts
@@ -1,20 +1,22 @@
-import { expect, test } from '@playwright/test';
+import { test as base, expect } from '@playwright/test';
 import { UsersPage } from '../lib/userspage.pom';
 
-test.describe('User List', () => {
-    let usersPage: UsersPage;
-    test.beforeEach(async ({ page }) => {
-        usersPage = new UsersPage(page);
+const test = base.extend<{ usersPage: UsersPage }>({
+    usersPage: async ({ page }, use) => {
+        const usersPage = new UsersPage(page);
         await usersPage.visit();
-    });
+        await use(usersPage);
+    }
+});
 
-    test('Search for vipgo', async ({ page }) => {
+test.describe('User List', () => {
+    test('Search for vipgo', async ({ usersPage }) => {
         await usersPage.searchForUsers('vipgo');
-        expect(await usersPage.usersFound()).toBe(true);
+        await expect(usersPage.noItemsLocator).toHaveCount(0);
     });
 
-    test('Search for non-existing user', async ({ page }) => {
+    test('Search for non-existing user', async ({ usersPage }) => {
         await usersPage.searchForUsers('this-user-does-not-exist');
-        expect(await usersPage.usersFound()).toBe(false);
+        await expect(usersPage.noItemsLocator).toHaveCount(1);
     });
 });


### PR DESCRIPTION
This pull request refactors the end-to-end test page object models and test specs to improve reliability and maintainability. The main changes involve switching from waiting for full page loads to waiting for the DOM content to be loaded, updating user search result checks, and enhancing test setup with Playwright's fixtures.

**Test reliability and navigation improvements:**

* Replaced all instances of `waitForLoadState('load')` with `waitForLoadState('domcontentloaded')` or more precise `waitForURL` calls after navigation and actions, ensuring faster and more reliable test execution. [[1]](diffhunk://#diff-bfc0ed7487a9a92653ee196314809447a07fcdc6195fcb4d5b8bff3bbcaceef2L86-R86) [[2]](diffhunk://#diff-0f2be3d08479baba823361220c91b15d31d4be712873c58c5050a9452a90f061L65-R67) [[3]](diffhunk://#diff-d2695e4f29d87b4b8587619a19e9d26550517e818b2efbdf39ec82740a04b7b7L45-R45) [[4]](diffhunk://#diff-5bab646eea189579331e0989c092ff0132309ec1b6c0300ffaf704a74d7bab13R19-R36) [[5]](diffhunk://#diff-5bab646eea189579331e0989c092ff0132309ec1b6c0300ffaf704a74d7bab13L53-L60)
* Updated navigation URLs in `UsersPage` to use relative paths for consistency.

**User search and result validation changes:**

* Added a new locator `noItemsLocator` to `UsersPage` for checking when no users are found, and removed the `usersFound` method in favor of direct locator assertions. [[1]](diffhunk://#diff-5bab646eea189579331e0989c092ff0132309ec1b6c0300ffaf704a74d7bab13R10) [[2]](diffhunk://#diff-5bab646eea189579331e0989c092ff0132309ec1b6c0300ffaf704a74d7bab13R19-R36) [[3]](diffhunk://#diff-5bab646eea189579331e0989c092ff0132309ec1b6c0300ffaf704a74d7bab13L53-L60)
* Updated user search tests to assert the count of `noItemsLocator` instead of using the removed `usersFound()` method, making the tests more robust and readable.

**Test setup improvements:**

* Refactored `users.spec.ts` to use Playwright's fixture extension for a cleaner and more maintainable test setup, injecting `UsersPage` into tests automatically.