### PR TITLE
Wire validate-integration to the VIP-CLI checker

### DIFF
--- a/bin/validate-integration.php
+++ b/bin/validate-integration.php
@@ -1,13 +1,36 @@
 <?php
 /**
- * Placeholder for the VIP-provided integration conformance validator.
+ * Runs the VIP integration conformance checker against this plugin.
  *
- * TODO: replace with the real validator once VIP publishes it. Until then
- * this placeholder exists so `composer run validate-integration` is present —
- * an integration requirement — and CI pipelines can already call it.
+ * Thin wrapper around `vip validate integration` (shipped in the VIP-CLI): it
+ * points the checker at the plugin root so `composer run validate-integration`
+ * works from anywhere and exits non-zero when the integration is not
+ * conformant, so it can gate CI.
+ *
+ * Requires the VIP-CLI: https://docs.wpvip.com/vip-cli/ (`npm install -g @automattic/vip`).
  */
 
-fwrite( STDOUT, 'validate-integration: the VIP conformance validator is not yet available.' . PHP_EOL );
-fwrite( STDOUT, 'This placeholder always succeeds and will be replaced by the VIP-provided checker.' . PHP_EOL );
+if ( PHP_SAPI !== 'cli' ) {
+	fwrite( STDERR, "validate-integration must be run from the command line.\n" );
+	exit( 1 );
+}
 
-exit( 0 );
+$plugin_root = dirname( __DIR__ );
+
+$vip_binary = trim( (string) shell_exec( 'command -v vip 2>/dev/null' ) );
+if ( '' === $vip_binary ) {
+	fwrite( STDERR, "VIP-CLI not found. Install it to validate the integration:\n" );
+	fwrite( STDERR, "  npm install -g @automattic/vip\n" );
+	fwrite( STDERR, "Then re-run: composer run validate-integration\n" );
+	exit( 1 );
+}
+
+$command = sprintf(
+	'%s validate integration %s',
+	escapeshellarg( $vip_binary ),
+	escapeshellarg( $plugin_root )
+);
+
+passthru( $command, $exit_code );
+
+exit( $exit_code );

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,6 @@
     "test": "Run PHPUnit and Playwright e2e tests (e2e needs a running vip dev-env)",
     "test:unit": "Run PHPUnit tests only",
     "test:e2e": "Run Playwright e2e tests only (needs a running vip dev-env)",
-    "validate-integration": "Run the VIP integration conformance validator (placeholder until VIP publishes it)"
+    "validate-integration": "Run the VIP integration conformance checker (runs `vip validate integration` via the VIP-CLI)"
   }
 }

--- a/docs/directories.md
+++ b/docs/directories.md
@@ -8,7 +8,7 @@
 | `fixtures/` | Mock runtime configs for local development and tests (see `fixtures/README.md`). |
 | `tests/phpunit/` | PHPUnit tests (run through `composer test:unit`). |
 | `tests/e2e/` | Playwright end-to-end tests (run through `composer test:e2e`; needs a running `vip dev-env`). |
-| `bin/` | Repo tooling: `setup.php` scaffold and the `validate-integration.php` stub. |
+| `bin/` | Repo tooling: `setup.php` scaffold and the `validate-integration.php` conformance-checker wrapper. |
 | `docs/` | Operational docs, including the required `vip-integration.md`. |
 | `.wpvip/` | VIP local development environment config and plugin loader. |
 | `.devcontainer/` | GitHub Codespaces configuration. |

--- a/docs/vip-integration.md
+++ b/docs/vip-integration.md
@@ -28,7 +28,7 @@ dev-env container (`vip dev-env shell`) it is preconfigured.
 | Install Node dependencies | `npm ci` |
 | Build release assets | not applicable — this integration ships no compiled JS/CSS assets (`npm run build` documents this) |
 | Tests | `composer test` |
-| Integration validation | `composer run validate-integration` (placeholder until VIP publishes the validator) |
+| Integration validation | `composer run validate-integration` (runs `vip validate integration` via the VIP-CLI) |
 
 ## Runtime Config
 


### PR DESCRIPTION
Replace the placeholder with a wrapper that runs `vip validate integration` against the plugin root and exits non-zero when it is not conformant, and update the docs to match.