### PR TITLE
Rename handoff manifest and CLI refs to vip- naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Center. It doubles as the reference implementation of the VIP integration
 requirements. The example integration exposes a small REST endpoint and reads
 its settings from a single VIP-provided config constant.
 
-A partner runs `composer setup` (or `a8c-integration init`) to rewrite the
+A partner runs `composer setup` (or `vip-integration init`) to rewrite the
 example names to theirs, writes their code under `inc/`, fills in
-`a8c-manifest.yaml`, and validates with `a8c-integration validate` before
+`vip-manifest.yaml`, and validates with `vip-integration validate` before
 submitting.
 
 ## Map
@@ -26,8 +26,8 @@ submitting.
 | `views/`                                          | Admin page templates.                                                                                      |
 | `fixtures/`                                       | Mock runtime configs for local dev and tests — see `fixtures/README.md`.                                   |
 | `tests/phpunit/`, `tests/e2e/`                    | PHPUnit and Playwright tests.                                                                              |
-| `a8c-manifest.yaml`                               | The handoff manifest VIP registers the integration from.                                                   |
-| `a8c-manifest.schema.json`                        | JSON Schema the manifest is validated against.                                                             |
+| `vip-manifest.yaml`                               | The handoff manifest VIP registers the integration from.                                                   |
+| `vip-manifest.schema.json`                        | JSON Schema the manifest is validated against.                                                             |
 | `bin/setup.php`                                   | The `composer setup` prefix-rewrite scaffolder.                                                            |
 | `docs/`                                           | Human docs. Start with `docs/vip-integration.md`.                                                          |
 | `.wpvip/`, `.devcontainer/`, `.github/workflows/` | VIP dev-env, Codespaces, and CI.                                                                           |
@@ -73,7 +73,7 @@ Read config only through `inc/class-config.php`. It reads the single
 VIP-provided constant, validates it, and exposes `is_ready()` /
 `missing_fields()` style accessors. New settings are added by:
 
-1. declaring the field in `a8c-manifest.yaml` (and its schema), and
+1. declaring the field in `vip-manifest.yaml` (and its schema), and
 2. reading it through `Config` — never touching the constant directly elsewhere.
 
 Whatever you add to `Config`, keep the graceful-degradation contract: with
@@ -87,7 +87,7 @@ Record events through `inc/class-telemetry.php` only. It wraps the VIP Tracks
 API behind a `class_exists` guard so non-VIP environments no-op. Event names are
 prefixed with the integration's snake_case name. Properties carry usage metadata
 only — never secrets, request payloads, emails, or credentials. Declare every
-event in the `telemetry` section of `a8c-manifest.yaml`.
+event in the `telemetry` section of `vip-manifest.yaml`.
 
 ### Tests
 
@@ -98,10 +98,10 @@ event in the `telemetry` section of `a8c-manifest.yaml`.
 
 ### Manifest
 
-`a8c-manifest.yaml` must stay in sync with the code: the constant name, the
+`vip-manifest.yaml` must stay in sync with the code: the constant name, the
 plugin folder/entry file/namespace, every config `key` the plugin reads, and the
-telemetry events it records. The schema (`a8c-manifest.schema.json`) rejects
-unknown keys, so a typo fails validation — run `a8c-integration validate` after
+telemetry events it records. The schema (`vip-manifest.schema.json`) rejects
+unknown keys, so a typo fails validation — run `vip-integration validate` after
 editing it. See `docs/manifest.md` for the field-by-field guide.
 
 ## Commands
@@ -144,14 +144,14 @@ composer psalm          # static analysis
 
 ### Validate the integration
 
-Conformance is checked by the external `a8c-integration` CLI (not a composer
+Conformance is checked by the external `vip-integration` CLI (not a composer
 script in this repo). Run it from the repo root:
 
 ```sh
-npx @automattic/a8c-integration validate            # human report
-npx @automattic/a8c-integration validate --format json   # for CI
+npx @automattic/vip-integration validate            # human report
+npx @automattic/vip-integration validate --format json   # for CI
 ```
 
 It exits non-zero when the integration is not conformant, so it can gate CI.
-Among other rules it validates `a8c-manifest.yaml` against
-`a8c-manifest.schema.json` — see `docs/manifest.md`.
+Among other rules it validates `vip-manifest.yaml` against
+`vip-manifest.schema.json` — see `docs/manifest.md`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It contains an example of fully configured VIP local and cloud development envir
 
 Utilizing these tools will allow you to submit the new versions of your integrations and us to deploy the code with confidence.
 
-The kit implements the WordPress VIP integration requirements and doubles as a reference implementation: runtime config via a single VIP-provided constant, config fixtures, Tracks telemetry, `composer test`, and the [handoff manifest](/docs/manifest.md) VIP registers the integration from. See [/docs/vip-integration.md](/docs/vip-integration.md) for the operational details. Check conformance with the [`a8c-integration`](https://github.com/Automattic/integration) CLI (`npx @automattic/a8c-integration validate`).
+The kit implements the WordPress VIP integration requirements and doubles as a reference implementation: runtime config via a single VIP-provided constant, config fixtures, Tracks telemetry, `composer test`, and the [handoff manifest](/docs/manifest.md) VIP registers the integration from. See [/docs/vip-integration.md](/docs/vip-integration.md) for the operational details. Check conformance with the [`vip-integration`](https://github.com/Automattic/integration) CLI (`npx @automattic/vip-integration validate`).
 
 ## Technology
 

--- a/docs/directories.md
+++ b/docs/directories.md
@@ -8,8 +8,8 @@
 | `fixtures/`                | Mock runtime configs for local development and tests (see `fixtures/README.md`).              |
 | `tests/phpunit/`           | PHPUnit tests (run through `composer test:unit`).                                             |
 | `tests/e2e/`               | Playwright end-to-end tests (run through `composer test:e2e`; needs a running `vip dev-env`). |
-| `a8c-manifest.yaml`        | The handoff manifest VIP registers and loads the integration from (see `docs/manifest.md`).   |
-| `a8c-manifest.schema.json` | JSON Schema the manifest is validated against.                                                |
+| `vip-manifest.yaml`        | The handoff manifest VIP registers and loads the integration from (see `docs/manifest.md`).   |
+| `vip-manifest.schema.json` | JSON Schema the manifest is validated against.                                                |
 | `bin/`                     | Repo tooling: the `setup.php` scaffold.                                                       |
 | `docs/`                    | Operational docs, including the required `vip-integration.md` and `manifest.md`.              |
 | `AGENTS.md`                | Orientation for AI coding agents working in this repo.                                        |

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -1,19 +1,19 @@
 # The handoff manifest
 
-`a8c-manifest.yaml` is the one file WordPress VIP uses to register and load your
+`vip-manifest.yaml` is the one file WordPress VIP uses to register and load your
 integration. VIP reads it, so everything VIP needs to wire up
 the plugin loader, the config form, and secret storage has to be declared here,
 correctly.
 
-This kit ships a filled-in example ([`a8c-manifest.yaml`](../a8c-manifest.yaml))
+This kit ships a filled-in example ([`vip-manifest.yaml`](../vip-manifest.yaml))
 and the schema it is validated against
-([`a8c-manifest.schema.json`](../a8c-manifest.schema.json)).
+([`vip-manifest.schema.json`](../vip-manifest.schema.json)).
 
 ```sh
-npx @automattic/a8c-integration validate
+npx @automattic/vip-integration validate
 ```
 
-`composer setup` (or `a8c-integration init`) rewrites the example names in the
+`composer setup` (or `vip-integration init`) rewrites the example names in the
 manifest to yours — slug, folder, entry file, namespace, and config constant —
 so most of the plumbing fields are filled in for you. You own the identity
 fields and the config schema.
@@ -122,7 +122,7 @@ Each entry in `events`:
 
 ## Keeping it honest
 
-The manifest is a contract. `a8c-integration validate` checks that it is present,
+The manifest is a contract. `vip-integration validate` checks that it is present,
 parses as YAML, and matches the schema exactly — including rejecting unknown or
 misspelled keys, since VIP loads your integration from these field names alone.
 It confirms the shape, not the values: that a URL resolves or a token is real is

--- a/docs/vip-integration.md
+++ b/docs/vip-integration.md
@@ -28,7 +28,7 @@ dev-env container (`vip dev-env shell`) it is preconfigured.
 | Install Node dependencies | `npm ci`                                                                                                       |
 | Build release assets      | not applicable — this integration ships no compiled JS/CSS assets (`npm run build` documents this)             |
 | Tests                     | `composer test`                                                                                                |
-| Integration validation    | `npx @automattic/a8c-integration validate` (the external conformance checker — see [manifest.md](manifest.md)) |
+| Integration validation    | `npx @automattic/vip-integration validate` (the external conformance checker — see [manifest.md](manifest.md)) |
 
 ## Runtime Config
 

--- a/vip-manifest.schema.json
+++ b/vip-manifest.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://automattic.github.io/vip-integration/a8c-manifest.schema.json",
+  "$id": "https://automattic.github.io/vip-integration/vip-manifest.schema.json",
   "title": "WordPress VIP Integration Handoff Manifest",
   "description": "The single file a partner fills in so VIP can register and load their integration without reading the plugin source.",
   "type": "object",

--- a/vip-manifest.yaml
+++ b/vip-manifest.yaml
@@ -1,13 +1,13 @@
-# yaml-language-server: $schema=./a8c-manifest.schema.json
+# yaml-language-server: $schema=./vip-manifest.schema.json
 #
 # Handoff manifest for the Example Integration.
 #
 # This is the single file WordPress VIP reads to register and load your
-# integration — VIP never sees your repo. `composer setup` (or `a8c-integration
+# integration — VIP never sees your repo. `composer setup` (or `vip-integration
 # init`) rewrites the example names below to yours. Fill in the rest, then check
-# it with `npx @automattic/a8c-integration validate`.
+# it with `npx @automattic/vip-integration validate`.
 #
-# See docs/manifest.md for a field-by-field guide, and a8c-manifest.schema.json
+# See docs/manifest.md for a field-by-field guide, and vip-manifest.schema.json
 # for the full schema (fields, types, and constraints).
 
 manifest_version: 1


### PR DESCRIPTION
Renames the handoff manifest and CLI references to the `vip-` naming across the Starter Kit:

- `a8c-manifest.yaml` → `vip-manifest.yaml`
- `a8c-manifest.schema.json` → `vip-manifest.schema.json`
- `a8c-integration` CLI references → `vip-integration` (docs, `README`, `AGENTS.md`)

Docs-and-rename only — no behavior changes. Pairs with the matching rename in the `vip-integration` CLI (`Automattic/integration`), which now looks for `vip-manifest.*`.
