### PR TITLE
Make plugin classes testable by removing constructor side effects

### DIFF
--- a/example-integration.php
+++ b/example-integration.php
@@ -26,4 +26,4 @@ define( 'VIP_EXAMPLE_INTEGRATION_FILE', __FILE__ );
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-Plugin::get_instance();
+Plugin::get_instance()->register();

--- a/inc/class-admin.php
+++ b/inc/class-admin.php
@@ -16,14 +16,17 @@ final class Admin {
 		return self::$instance;
 	}
 
-	private function __construct() {
-		$this->init();
+	/**
+	 * Register the admin UI with WordPress.
+	 */
+	public static function register(): void {
+		self::get_instance()->init();
 	}
 
 	public function init(): void {
 		add_action( 'admin_menu', [ $this, 'admin_menu' ] );
 		add_action( 'admin_init', [ $this, 'admin_init' ] );
-		add_action( 'admin_init', [ AdminSettings::class, 'get_instance' ] );
+		add_action( 'admin_init', [ AdminSettings::class, 'register' ] );
 	}
 
 	public function admin_init(): void {

--- a/inc/class-adminsettings.php
+++ b/inc/class-adminsettings.php
@@ -8,29 +8,32 @@ final class AdminSettings {
 	/** @var self|null */
 	private static $instance;
 
+	/** @var InputFactory */
+	private $input_factory;
+
 	public static function get_instance(): self {
 		if ( ! self::$instance ) {
-			// @codeCoverageIgnoreStart
-			// Depending on the test order, this may not be testable
-			self::$instance = new self();
-			// @codeCoverageIgnoreEnd
+			self::$instance = new self( new InputFactory( Settings::OPTIONS_KEY, Settings::get_instance() ) );
 		}
 
 		return self::$instance;
 	}
 
-	/** @var InputFactory */
-	private $input_factory;
+	/**
+	 * Register the plugin's setting, section, and fields.
+	 */
+	public static function register(): void {
+		self::get_instance()->register_settings();
+	}
 
 	/**
-	 * @codeCoverageIgnore -- coverage depends on the test order
+	 * @param InputFactory $input_factory Renders the settings fields.
 	 */
-	private function __construct() {
-		$this->register_settings();
+	public function __construct( InputFactory $input_factory ) {
+		$this->input_factory = $input_factory;
 	}
 
 	public function register_settings(): void {
-		$this->input_factory = new InputFactory( Settings::OPTIONS_KEY, Settings::get_instance() );
 		register_setting(
 			self::OPTION_GROUP,
 			Settings::OPTIONS_KEY,

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -16,16 +16,21 @@ final class Plugin {
 		return self::$instance;
 	}
 
-	private function __construct() {
+	/**
+	 * Register the plugin's hooks with WordPress.
+	 *
+	 * The plugin entry file calls this during load.
+	 */
+	public function register(): void {
 		add_action( 'init', [ $this, 'init' ] );
 		if ( is_admin() ) {
-			add_action( 'init', [ Admin::class, 'get_instance' ] );
+			add_action( 'init', [ Admin::class, 'register' ] );
 		}
 	}
 
 	public function init(): void {
 		if ( Config::get_instance()->is_ready() ) {
-			add_action( 'rest_api_init', [ REST_Controller::class, 'get_instance' ] );
+			add_action( 'rest_api_init', [ REST_Controller::class, 'register' ] );
 		} else {
 			// Missing or incomplete runtime config must never fatal: disable the
 			// config-dependent behavior and surface a diagnostic instead.

--- a/inc/class-rest-controller.php
+++ b/inc/class-rest-controller.php
@@ -20,8 +20,11 @@ final class REST_Controller {
 		return self::$instance;
 	}
 
-	private function __construct() {
-		$this->register_routes();
+	/**
+	 * Register the plugin's REST API routes.
+	 */
+	public static function register(): void {
+		self::get_instance()->register_routes();
 	}
 
 	public function register_routes(): void {

--- a/tests/phpunit/AdminSettingsTest.php
+++ b/tests/phpunit/AdminSettingsTest.php
@@ -32,19 +32,20 @@ class AdminSettingsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * register_settings() registers the setting, its section, and its fields.
+	 *
 	 * @global mixed[] $wp_settings_sections
 	 * @global mixed[] $wp_settings_fields
-	 *
-	 * @uses ExampleVendor\ExampleIntegration\SettingsValidator::ensure_data_shape
 	 */
-	public function test_construct(): void {
+	public function test_register_settings(): void {
 		global $wp_settings_sections;
 		global $wp_settings_fields;
 
 		/** @psalm-var array<string, array<string, mixed>> $wp_settings_sections */
 		/** @psalm-var array<string, array<string, mixed>> $wp_settings_fields */
 
-		AdminSettings::get_instance()->register_settings();
+		$admin_settings = new AdminSettings( new InputFactory( Settings::OPTIONS_KEY, Settings::get_instance() ) );
+		$admin_settings->register_settings();
 
 		self::assertArrayHasKey( Admin::OPTIONS_MENU_SLUG, $wp_settings_sections );
 		self::assertArrayHasKey( 'general-settings', $wp_settings_sections[ Admin::OPTIONS_MENU_SLUG ] );
@@ -54,6 +55,22 @@ class AdminSettingsTest extends WP_UnitTestCase {
 
 		self::assertArrayHasKey( 'enabled', $wp_settings_fields[ Admin::OPTIONS_MENU_SLUG ]['general-settings'] );
 		self::assertArrayHasKey( 'message', $wp_settings_fields[ Admin::OPTIONS_MENU_SLUG ]['general-settings'] );
+	}
+
+	/**
+	 * register() registers the settings and reuses a single instance.
+	 *
+	 * @global mixed[] $wp_settings_fields
+	 */
+	public function test_register(): void {
+		global $wp_settings_fields;
+
+		/** @psalm-var array<string, array<string, mixed>> $wp_settings_fields */
+
+		AdminSettings::register();
+
+		self::assertArrayHasKey( Admin::OPTIONS_MENU_SLUG, $wp_settings_fields );
+		self::assertSame( AdminSettings::get_instance(), AdminSettings::get_instance() );
 	}
 
 	public function testSettingsPage_guest(): void {

--- a/tests/phpunit/AdminTest.php
+++ b/tests/phpunit/AdminTest.php
@@ -24,12 +24,13 @@ class AdminTest extends WP_UnitTestCase {
 		wp_set_current_user( static::$admin_id );
 	}
 
-	public function test_construct(): void {
+	public function test_register(): void {
+		Admin::register();
 		$admin = Admin::get_instance();
-		$admin->init();
 
 		static::assertEquals( 10, has_action( 'admin_init', [ $admin, 'admin_init' ] ) );
 		static::assertEquals( 10, has_action( 'admin_menu', [ $admin, 'admin_menu' ] ) );
+		static::assertEquals( 10, has_action( 'admin_init', [ AdminSettings::class, 'register' ] ) );
 	}
 
 	public function test_admin_init(): void {

--- a/tests/phpunit/PluginTest.php
+++ b/tests/phpunit/PluginTest.php
@@ -20,11 +20,11 @@ class PluginTest extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
-	public function test_construct(): void {
+	public function test_register_wires_hooks(): void {
 		$plugin = Plugin::get_instance();
 
 		static::assertEquals( 10, has_action( 'init', [ $plugin, 'init' ] ) );
-		static::assertEquals( 10, has_action( 'rest_api_init', [ REST_Controller::class, 'get_instance' ] ) );
+		static::assertEquals( 10, has_action( 'rest_api_init', [ REST_Controller::class, 'register' ] ) );
 		static::assertEquals( 10, has_action( 'wp_footer', [ $plugin, 'wp_footer' ] ) );
 	}
 

--- a/tests/phpunit/RESTControllerTest.php
+++ b/tests/phpunit/RESTControllerTest.php
@@ -24,7 +24,7 @@ class RESTControllerTest extends WP_Test_REST_TestCase {
 
 		$wp_rest_server = new Spy_REST_Server();
 		do_action( 'rest_api_init', $wp_rest_server );
-		REST_Controller::get_instance()->register_routes();
+		REST_Controller::register();
 
 		wp_set_current_user( 1 );
 	}


### PR DESCRIPTION
## Summary

`Plugin`, `Admin`, `AdminSettings`, and `REST_Controller` each did their WordPress wiring from the constructor, whether by adding hooks or by registering settings and REST routes. Because construction and registration were fused, there was no way to instantiate one of these objects without it immediately wiring itself into WordPress. That blocks the ordinary unit-testing pattern of building an object, adjusting a property, and calling a single method in isolation. It also forced a couple of `@codeCoverageIgnore` workarounds, since whether a constructor line counted as covered depended on which randomly-ordered test happened to trigger the singleton first.

This change follows the rule that a constructor should set up an object's properties and nothing else. The registration logic moves into explicit `register()` entry points, mirroring `Config` and `InputFactory`, which already followed this pattern. `AdminSettings` now receives its `InputFactory` as a constructor dependency instead of creating one as a side effect, so it can be built and exercised directly in a test. With the side effects gone, the coverage-ignore workarounds are no longer needed and have been removed.

The child classes expose `register()` as a static method so it can be used directly as a hook callback, while `Plugin::register()` is an instance method the entry file calls explicitly during load. Behaviour is unchanged: the same hooks, settings, and routes are registered at exactly the same points in the WordPress lifecycle. The tests are updated to call the new entry points and to demonstrate the direct-construction path that is now possible.

Closes #188.

## Test plan

- [ ] `composer phpcs` passes
- [ ] `composer psalm` passes
- [ ] `composer test:unit` passes (PHPUnit)