### PR TITLE
Update workflow actions to latest, pin to SHAs, and harden

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,15 +13,19 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: 'ubuntu-latest'
     permissions:
-      security-events: write
-      packages: read
-      actions: read
-      contents: read
+      security-events: write  # upload CodeQL results to code scanning
+      packages: read          # fetch CodeQL packs and dependencies
+      actions: read           # read workflow metadata for the actions analysis
+      contents: read          # check out the repository
 
     strategy:
       fail-fast: false
@@ -33,17 +37,19 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.6
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.6
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,13 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     name: Review Dependencies
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read        # read the dependency graph and check out the repo
+      pull-requests: write  # post the dependency review summary comment
     steps:
       - name: Check out the source code
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.1.7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Review dependencies
-        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           comment-summary-in-pr: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,10 +28,12 @@ jobs:
     name: E2E Tests on WordPress ${{ matrix.wordpress }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.1.7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         env:
           fail-fast: 'true'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,10 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.1.7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           coverage: none
         env:

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -22,10 +22,12 @@ jobs:
     name: Psalm
     steps:
       - name: Check out source code
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.1.7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           coverage: none
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,7 +49,7 @@ jobs:
           - { wp: nightly, ms: 'yes', php: '8.5' }
     services:
       mysql:
-        image: mariadb:latest
+        image: mariadb:lts@sha256:759869cb6f003234a95c6384cdee245b4bce7de26913fe607a8110362c0c007d
         ports:
           - "3306:3306"
         env:
@@ -60,7 +60,9 @@ jobs:
           MYSQL_DATABASE: wordpress_test
     steps:
       - name: Check out source code
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.1.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install subversion
         run: sudo apt-get update && sudo apt-get install subversion
@@ -76,7 +78,7 @@ jobs:
           fi
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           coverage: ${{ steps.coverage.outputs.coverage }}
           ini-values: ${{ steps.coverage.outputs.ini }}
@@ -88,7 +90,7 @@ jobs:
         uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
       - name: Set up WordPress and WordPress Test Library
-        uses: sjinks/setup-wordpress-test-library@9726426f2a40656274560a0394718177f8adb424 # 3.0.0
+        uses: sjinks/setup-wordpress-test-library@9726426f2a40656274560a0394718177f8adb424 # v3.0.0
         with:
           version: ${{ matrix.config.wp }}
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.1.7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0


### PR DESCRIPTION
## Summary

The `actions/checkout` pins had drifted to an untagged commit while their comments still claimed v4.1.7/v4.1.1 — a Dependabot artefact that leaves the pins unverifiable and no longer tracked. Correcting that touched every `uses:` anyway, so this brings all actions to their latest release and SHA-pins each; the resulting set matches the `connector-controls` reference and is `pinact --verify` clean.

Both major bumps are safe for our usage: checkout v7 only tightens fork handling for `pull_request_target`/`workflow_run` (unused here), and dependency-review v5 keeps the `comment-summary-in-pr` input we rely on.

The remainder is zizmor hardening: `persist-credentials: false` where no job reuses the token, the MariaDB service pinned by digest off the mutable `:latest` (matching `connector-controls`), a concurrency group on CodeQL, and a comment on each elevated permission. Four `template-injection` findings are left as-is — all on internal, non-attacker-controllable values.

## Test plan

- [ ] CI passes: lint, static analysis, unit tests, CodeQL, dependency review. E2E is failing pre-existing and flaky on `main` and on `connector-controls` alike (same `vip dev-env` harness), so it is unrelated to these workflow-only changes.