### PR TITLE
Label Dependabot PRs as dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     labels:
-      - "[Status] Needs Review"
+      - "dependencies"
 
   - package-ecosystem: "composer"
     directory: "/"
@@ -13,7 +13,7 @@ updates:
       interval: "weekly"
     versioning-strategy: "increase-if-necessary"
     labels:
-      - "[Status] Needs Review"
+      - "dependencies"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -21,4 +21,4 @@ updates:
       interval: "weekly"
     versioning-strategy: "increase-if-necessary"
     labels:
-      - "[Status] Needs Review"
+      - "dependencies"


### PR DESCRIPTION
## Summary

Dependabot PRs were previously tagged with the `[Status] Needs Review` label across all three ecosystems (github-actions, composer, and npm). That label ties automated dependency bumps into a review-status workflow, which conflates "this PR needs human triage" with "this is a routine dependency update". It also meant Dependabot PRs weren't grouped under the conventional `dependencies` label that most tooling and filters expect.

This change replaces `[Status] Needs Review` with a single `dependencies` label for every ecosystem, so Dependabot PRs are categorised consistently and predictably.

PRs, by default, require a review, so a Needs Review label is redundant.

Note: for the label to attach, a `dependencies` label must exist in the repository. Dependabot does not create labels itself, and a missing label is silently skipped.