### PR TITLE
Fix the strings that read wrongly after composer setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@ matches your task.
 The **WordPress VIP Integration Starter Kit**: a complete, runnable WordPress VIP
 plugin that a partner clones to build an integration for the VIP Integration
 Center. It doubles as the reference implementation of the VIP integration
-requirements. The example integration exposes a small REST endpoint and reads
-its settings from a single VIP-provided config constant.
+requirements. The plugin exposes a small REST endpoint and reads its settings
+from a single VIP-provided config constant.
 
 A partner runs `composer setup` (or `vip-integration init`) to rewrite the
 example names to theirs, writes their code under `inc/`, fills in

--- a/docs/vip-integration.md
+++ b/docs/vip-integration.md
@@ -1,10 +1,10 @@
 # VIP Integration
 
-Example Integration is the reference implementation of a WordPress VIP partner
-integration, built from the [VIP Integrations Starter Kit](https://github.com/Automattic/vip-integrations-starter-kit).
-It demonstrates the patterns WordPress VIP requires of partner integrations: a single runtime config constant read through a central `Config`
-class, graceful degradation when required config is missing, and Tracks-only
-telemetry through the VIP Telemetry API.
+Example Integration is built from the [VIP Integrations Starter Kit](https://github.com/Automattic/vip-integrations-starter-kit)
+and follows the patterns WordPress VIP requires of partner integrations: a
+single runtime config constant read through a central `Config` class, graceful
+degradation when required config is missing, and Tracks-only telemetry through
+the VIP Telemetry API.
 
 ## Running and testing locally
 
@@ -93,6 +93,25 @@ via plain string replacement:
 | `VIP_EXAMPLE_INTEGRATION_*` (constants)                                       | `VIP_<YOUR_NAME>_*`                 |
 | `example_integration_` (telemetry prefix, option keys)                        | `<your_name>_`                      |
 | `example-vendor/example-integration` (Composer name)                          | `<your-vendor>/<your-slug>`         |
+| `Example Integration` (display name, plugin name, UI strings)                 | your integration name, title case   |
+| `Example Vendor` (plugin author, manifest partner name)                       | your vendor name, title case        |
 
 Run it interactively (`composer setup`) or non-interactively
 (`composer setup -- --vendor="Acme" --name="Content Sync"`).
+
+### What setup cannot fill in
+
+The rewrite only derives tokens from the vendor and integration names you give
+it, so prose and contact details are left as the kit's examples. Work through
+these before handing off:
+
+| Where                    | What                                                                        |
+| ------------------------ | --------------------------------------------------------------------------- |
+| `vip-manifest.yaml`      | `integration.summary` — the one-line description shown on the catalog card. |
+| `vip-manifest.yaml`      | `integration.partner.support_contact` — still `support@example.com`.        |
+| `vip-manifest.yaml`      | `documentation.public_url` and `support_url` — still `example.com` URLs.    |
+| `<your-slug>.php`        | `Description` in the plugin header — still describes the Starter Kit.       |
+| `README.md`, `AGENTS.md` | Both still introduce the repo as the Starter Kit, not your integration.     |
+
+`npx @automattic/vip-integration validate` passes with the example values in
+place, so it will not catch these for you.

--- a/vip-manifest.yaml
+++ b/vip-manifest.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=./vip-manifest.schema.json
 #
-# Handoff manifest for the Example Integration.
+# Handoff manifest for Example Integration.
 #
 # This is the single file WordPress VIP reads to register and load your
 # integration — VIP never sees your repo. `composer setup` (or `vip-integration


### PR DESCRIPTION
## Summary

`composer setup` rewrites the kit's example prefix set by plain string replacement, which puts a quiet constraint on every string in the repo: it has to read correctly both before and after the rewrite. Three did not, and running setup on a throwaway clone as `--vendor="Automattic" --name="Live Previews"` shows each one.

The manifest's opening comment read "Handoff manifest for the Example Integration", which came out as "Handoff manifest for the Live Previews". The article only works with the example name, so it is gone. AGENTS.md described what "the example integration" exposes in lower case — a form deliberately absent from the replacement map, so it survived the rewrite untouched and went stale the moment anyone ran setup; it now says "the plugin", which is true either side of the rename. And `docs/vip-integration.md` opened by calling the plugin "the reference implementation of a WordPress VIP partner integration", which is a claim about the kit rather than about whatever a partner builds from it.

While in that document, the token table needed two more rows. `bin/setup.php` cites it as "the token table this maintains", but it documented only six of the eight replacements the script actually performs. The two missing entries were `Example Integration` and `Example Vendor` — precisely the ones that reach display names, the plugin header and the manifest partner name, so they are the most visible and the most surprising to find undocumented.

The last addition is a "What setup cannot fill in" subsection. Setup can only derive tokens from the vendor and integration names, which leaves the manifest summary, support contact and documentation URLs, the plugin header description, and the README and AGENTS.md self-description as the kit's examples. That is worth writing down explicitly because `npx @automattic/vip-integration validate` reports a conformant integration with `support@example.com` and `example.com` URLs still in place, so nothing downstream will raise it.

Reviewers may want to check that the new subsection sits *after* the `## Making it your own` marker, since `bin/setup.php` preserves everything from that heading onward and the section relies on keeping its example tokens verbatim.

## Related

#207 adds the matching runtime checklist, so setup itself reports the same list when it finishes. The two touch disjoint files and can merge in either order.

Worth raising separately against `Automattic/integration`: the conformance checker's manifest rule reports the result as "placeholder-free" while `support@example.com` and the `example.com` documentation URLs pass through it unflagged.

## Test plan

- [x] `php bin/setup.php --vendor="Automattic" --name="Live Previews"` on a throwaway clone — all three strings now read correctly after the rewrite
- [x] The preserved token table still keeps its example tokens, including the two new rows
- [x] `npx @automattic/vip-integration validate` — still 9 passed, 0 failed