### PR TITLE
Have setup report the example values it cannot derive

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ npm i
 composer setup
 ```
 
+Setup finishes by listing the example values it cannot derive from your names — the manifest summary, support contact and documentation URLs, the plugin header description, and this README. Work through that list before submitting: the conformance checker passes with those values still in place, so nothing downstream will flag them. See [Making it your own](/docs/vip-integration.md#making-it-your-own) for the full table.
+
 6. Create and start a WPVIP local development instance:
 
 ```sh

--- a/bin/setup.php
+++ b/bin/setup.php
@@ -99,12 +99,88 @@ if ( file_exists( 'example-integration.php' ) ) {
 
 fwrite( STDOUT, "Rewrote {$changed} file(s).\n" );
 fwrite( STDOUT, "Prefix set: slug={$name_kebab}, namespace={$vendor_pascal}\\{$name_pascal}, constant=VIP_{$name_upper}_CONFIG\n" );
+
+$outstanding = outstanding_examples( "{$name_kebab}.php" );
+
+if ( [] !== $outstanding ) {
+	fwrite( STDOUT, "\nStill the kit's example values — a name rewrite cannot derive these:\n" );
+
+	foreach ( $outstanding as $file => $descriptions ) {
+		fwrite( STDOUT, "  {$file}\n" );
+
+		foreach ( $descriptions as $description ) {
+			fwrite( STDOUT, "    - {$description}\n" );
+		}
+	}
+
+	fwrite( STDOUT, "  `vip-integration validate` reports a conformant integration with these\n" );
+	fwrite( STDOUT, "  left in place, so it will not catch them for you.\n\n" );
+}
+
+$steps = [ 'Review the changes: git diff' ];
+
+if ( [] !== $outstanding ) {
+	$steps[] = 'Replace the example values listed above';
+}
+
+$steps[] = 'Refresh the Composer lock hash: composer update --lock';
+$steps[] = 'Recreate your local environment if one exists: vip dev-env destroy && vip dev-env create';
+
 fwrite( STDOUT, "Next steps:\n" );
-fwrite( STDOUT, "  1. Review the changes: git diff\n" );
-fwrite( STDOUT, "  2. Refresh the Composer lock hash: composer update --lock\n" );
-fwrite( STDOUT, "  3. Recreate your local environment if one exists: vip dev-env destroy && vip dev-env create\n" );
+
+foreach ( $steps as $index => $step ) {
+	fwrite( STDOUT, sprintf( "  %d. %s\n", $index + 1, $step ) );
+}
 
 exit( 0 );
+
+/**
+ * Example values that outlive the rewrite because they are prose and contact
+ * details rather than names derived from the vendor and integration.
+ *
+ * Each needle is deliberately absent from the replacement map above, so it
+ * survives setup and stops matching only once the value is genuinely replaced.
+ * Re-running setup after that reports nothing for it.
+ *
+ * @param string $entry_file The renamed plugin entry file.
+ * @return array<string, list<string>> Descriptions of what to replace, keyed by file.
+ */
+function outstanding_examples( string $entry_file ): array {
+	$checks = [
+		'vip-manifest.yaml' => [
+			'Reference integration built from the VIP Integrations Starter Kit.' => 'integration.summary — the one-line description on the catalog card',
+			'support@example.com'                                               => 'integration.partner.support_contact',
+			'https://example.com'                                               => 'documentation.public_url and documentation.support_url',
+		],
+		$entry_file         => [
+			'built from the VIP Integrations Starter Kit' => 'Description in the plugin header',
+		],
+		'README.md'         => [
+			'# WordPress VIP Integration Starter Kit' => 'still introduces the repo as the Starter Kit, not your integration',
+		],
+		'AGENTS.md'         => [
+			'The **WordPress VIP Integration Starter Kit**' => 'still describes the repo as the Starter Kit, not your integration',
+		],
+	];
+
+	$outstanding = [];
+
+	foreach ( $checks as $file => $needles ) {
+		if ( ! is_file( $file ) ) {
+			continue;
+		}
+
+		$contents = (string) file_get_contents( $file );
+
+		foreach ( $needles as $needle => $description ) {
+			if ( str_contains( $contents, $needle ) ) {
+				$outstanding[ $file ][] = $description;
+			}
+		}
+	}
+
+	return $outstanding;
+}
 
 function prompt( string $label ): string {
 	fwrite( STDOUT, "{$label}: " );


### PR DESCRIPTION
## Summary

`composer setup` rewrites every token it can derive from the vendor and integration names, prints a three-line summary, and exits. What it never mentions is everything it could not touch. Afterwards the manifest summary, the partner support contact, the documentation URLs, the plugin header description, and the README and AGENTS.md self-description are all still the kit's examples, and a partner has no particular reason to suspect it.

Nothing downstream catches it either, which is the part that makes this worth fixing rather than documenting. `npx @automattic/vip-integration validate` returns 9 passed, 0 failed on a freshly-set-up repo with `support@example.com` and `https://example.com/docs/...` sitting in the manifest, and its manifest rule describes the result as "placeholder-free". So the first person to notice is whoever picks up the VIP review, long after the partner has moved on to writing actual code.

Setup now checks which of those example values genuinely remain and prints them grouped by file, and adds a numbered next step for as long as any are outstanding. Every needle it looks for is absent from the replacement map, so it survives the rewrite and stops matching only once the value is really replaced — a partner who fills everything in and re-runs setup sees a clean run rather than a permanent nag. `README.md` step 5 gains a pointer so the list is discoverable before you run anything.

The obvious alternative was to write `TODO` markers straight into the manifest and let validation catch them. That turns out to be actively harmful: `documentation.public_url` is constrained to `^https?://.+`, so a `TODO` would fail the schema the moment setup finished and leave a partner debugging their own scaffolding on day one. Reporting is the gentler mechanism, at the cost of relying on someone reading the output.

One thing reviewers should weigh: `bin/setup.php` sits outside both the phpcs and psalm scan paths, so this code is not covered by either. It is straightforward procedural PHP in the style of the surrounding file, but it is unlinted by construction.

## Related

#206 documents the same list in `docs/vip-integration.md` and fixes several strings that read wrongly after the rewrite. The two touch disjoint files and can merge in either order.

Worth raising separately against `Automattic/integration`: the checker's "placeholder-free" claim does not detect `example.com` values.

## Test plan

- [x] Fresh kit, `--vendor="Automattic" --name="Live Previews"` — reports all five groups and four next steps
- [x] Same clone with every value filled in, setup re-run — reports nothing outstanding and drops back to three next steps
- [x] `php -l bin/setup.php` clean
- [x] `npx @automattic/vip-integration validate` — still 9 passed, 0 failed